### PR TITLE
Form data server side storage (Poc, don't merge)

### DIFF
--- a/app/cookies.server.ts
+++ b/app/cookies.server.ts
@@ -3,7 +3,7 @@ import { useSecureCookie } from "~/util/useSecureCookie";
 import invariant from "tiny-invariant";
 import crypto from "crypto";
 import { GrundModel } from "~/domain/steps/index.server";
-import encryption from "./services/encryption";
+import { encrypt, decrypt } from "./services/encryption";
 
 export const COOKIE_ENCODING = "base64";
 
@@ -90,11 +90,11 @@ export const createFormDataCookie: CreateFormDataCookieFunction = ({
 export const encryptCookie = (data: any) => {
   const key = process.env.FORM_COOKIE_ENC_SECRET as string;
   const serializedData = Buffer.from(JSON.stringify(data), "utf-8");
-  return encryption(key).encrypt(serializedData).toString(COOKIE_ENCODING);
+  return encrypt({ data: serializedData, key }).toString(COOKIE_ENCODING);
 };
 
 export const decryptCookie = (encryptedData: Buffer) => {
   const key = process.env.FORM_COOKIE_ENC_SECRET as string;
-  const decryptedData = encryption(key).decrypt(encryptedData);
+  const decryptedData = decrypt({ data: encryptedData, key });
   return JSON.parse(decryptedData.toString("utf-8"));
 };

--- a/app/cookies.server.ts
+++ b/app/cookies.server.ts
@@ -3,8 +3,8 @@ import { useSecureCookie } from "~/util/useSecureCookie";
 import invariant from "tiny-invariant";
 import crypto from "crypto";
 import { GrundModel } from "~/domain/steps/index.server";
+import encryption from "./services/encryption";
 
-const KEY_VERSION = "v01";
 export const COOKIE_ENCODING = "base64";
 
 type PruefenCookieData = any;
@@ -87,39 +87,14 @@ export const createFormDataCookie: CreateFormDataCookieFunction = ({
   });
 };
 
-export const encryptCookie = (
-  cookie: { userId: string; data?: GrundModel } | PruefenCookieData
-) => {
-  const key = Buffer.from(process.env.FORM_COOKIE_ENC_SECRET as string);
-  const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
-  const stringifiedData = JSON.stringify(cookie);
-  const encryptedCookie = Buffer.concat([
-    Buffer.from(KEY_VERSION),
-    iv,
-    cipher.update(stringifiedData),
-    cipher.final(),
-    cipher.getAuthTag(),
-  ]);
-  return encryptedCookie.toString(COOKIE_ENCODING);
+export const encryptCookie = (data: any) => {
+  const key = process.env.FORM_COOKIE_ENC_SECRET as string;
+  const serializedData = Buffer.from(JSON.stringify(data), "utf-8");
+  return encryption(key).encrypt(serializedData).toString(COOKIE_ENCODING);
 };
 
-export const decryptCookie = (
-  encryptedCookie: Buffer
-): { userId: string; data?: GrundModel } | PruefenCookieData => {
-  const key = Buffer.from(process.env.FORM_COOKIE_ENC_SECRET as string);
-  // ignoring key version for now since no key rotation is implemented
-  const iv = encryptedCookie.subarray(3, 16 + 3);
-  const ciphertext = encryptedCookie.subarray(
-    16 + 3,
-    encryptedCookie.length - 16
-  );
-  const authTag = encryptedCookie.subarray(encryptedCookie.length - 16);
-  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
-  decipher.setAuthTag(authTag);
-  const decryptedCookie = Buffer.concat([
-    decipher.update(ciphertext),
-    decipher.final(),
-  ]);
-  return JSON.parse(decryptedCookie.toString("utf-8"));
+export const decryptCookie = (encryptedData: Buffer) => {
+  const key = process.env.FORM_COOKIE_ENC_SECRET as string;
+  const decryptedData = encryption(key).decrypt(encryptedData);
+  return JSON.parse(decryptedData.toString("utf-8"));
 };

--- a/app/domain/user.ts
+++ b/app/domain/user.ts
@@ -239,6 +239,13 @@ export const setUserInFscNeuBeantragenProcess = async (
   });
 };
 
+export const saveFormData = async (id: string, formData: object) => {
+  return db.user.update({
+    where: { id },
+    data: { formData },
+  });
+};
+
 export const getAllEricaRequestIds = async () => {
   return db.user.findMany({
     select: {

--- a/app/redis/redis.server.ts
+++ b/app/redis/redis.server.ts
@@ -6,7 +6,6 @@ export enum Feature {
   RATE_LIMIT = "rate",
   BUNDES_IDENT_RATE_LIMIT = "bundesIdentRate",
   CLIENT_IP = "clientIp",
-  FORM_DATA = "formData",
 }
 
 declare global {

--- a/app/redis/redis.server.ts
+++ b/app/redis/redis.server.ts
@@ -6,6 +6,7 @@ export enum Feature {
   RATE_LIMIT = "rate",
   BUNDES_IDENT_RATE_LIMIT = "bundesIdentRate",
   CLIENT_IP = "clientIp",
+  FORM_DATA = "formData",
 }
 
 declare global {

--- a/app/routes/formular/_anzahlAction.ts
+++ b/app/routes/formular/_anzahlAction.ts
@@ -3,6 +3,7 @@ import _ from "lodash";
 import {
   createHeadersWithFormDataCookie,
   getStoredFormData,
+  storeFormData,
 } from "~/formDataStorage.server";
 import { authenticator } from "~/auth.server";
 import { verifyCsrfToken } from "~/util/csrf";
@@ -101,6 +102,8 @@ export const action: ActionFunction = async (args) => {
       listOfItems
     );
   }
+
+  await storeFormData({ data: formDataToBeStored, user });
 
   const headers = await createHeadersWithFormDataCookie({
     data: formDataToBeStored,

--- a/app/routes/formular/_step.tsx
+++ b/app/routes/formular/_step.tsx
@@ -22,6 +22,7 @@ import {
 import {
   createHeadersWithFormDataCookie,
   getStoredFormData,
+  storeFormData,
 } from "~/formDataStorage.server";
 import { getStepData, setStepData, StepFormData } from "~/domain/model";
 import {
@@ -219,6 +220,9 @@ export const action: ActionFunction = async ({ params, request }) => {
     currentState,
     validatedStepData
   ) as GrundModel;
+
+  await storeFormData({ data: formDataToBeStored, user });
+
   const headers = await createHeadersWithFormDataCookie({
     data: formDataToBeStored,
     user,

--- a/app/routes/formular/weitereErklaerung.tsx
+++ b/app/routes/formular/weitereErklaerung.tsx
@@ -31,6 +31,7 @@ import Hint from "~/components/Hint";
 import {
   createHeadersWithFormDataCookie,
   getStoredFormData,
+  storeFormData,
 } from "~/formDataStorage.server";
 import { authenticator } from "~/auth.server";
 import {
@@ -112,6 +113,9 @@ export const action: ActionFunction = async ({ request }) => {
         },
       };
     }
+
+    await storeFormData({ data: formDataToBeStored, user });
+
     const headers = await createHeadersWithFormDataCookie({
       data: formDataToBeStored,
       user,

--- a/app/routes/formular/zusammenfassung.tsx
+++ b/app/routes/formular/zusammenfassung.tsx
@@ -15,6 +15,7 @@ import {
 import {
   createHeadersWithFormDataCookie,
   getStoredFormData,
+  storeFormData,
 } from "~/formDataStorage.server";
 import {
   getStepDefinition,
@@ -315,6 +316,8 @@ export const action: ActionFunction = async ({
     "zusammenfassung",
     validatedStepData
   ) as GrundModel;
+
+  await storeFormData({ data: formDataToBeStored, user });
 
   const headers = await createHeadersWithFormDataCookie({
     data: formDataToBeStored,

--- a/app/services/encryption.test.ts
+++ b/app/services/encryption.test.ts
@@ -1,0 +1,19 @@
+import encryption from "./encryption";
+
+const KEY = "0123456789_0123456789_0123456789";
+const data = Buffer.from("hallo welt!", "utf8");
+const encryptedData = encryption(KEY).encrypt(data);
+
+describe("encryption", () => {
+  describe("encrypt", () => {
+    it("returns encrypted data", () => {
+      expect(encryptedData).not.toContain(data);
+    });
+  });
+
+  describe("decrypt", () => {
+    it("returns decrypted data", () => {
+      expect(encryption(KEY).decrypt(encryptedData)).toEqual(data);
+    });
+  });
+});

--- a/app/services/encryption.test.ts
+++ b/app/services/encryption.test.ts
@@ -1,8 +1,8 @@
-import encryption from "./encryption";
+import { encrypt, decrypt } from "./encryption";
 
-const KEY = "0123456789_0123456789_0123456789";
+const key = "0123456789_0123456789_0123456789";
 const data = Buffer.from("hallo welt!", "utf8");
-const encryptedData = encryption(KEY).encrypt(data);
+const encryptedData = encrypt({ data, key });
 
 describe("encryption", () => {
   describe("encrypt", () => {
@@ -13,7 +13,7 @@ describe("encryption", () => {
 
   describe("decrypt", () => {
     it("returns decrypted data", () => {
-      expect(encryption(KEY).decrypt(encryptedData)).toEqual(data);
+      expect(decrypt({ data: encryptedData, key })).toEqual(data);
     });
   });
 });

--- a/app/services/encryption.ts
+++ b/app/services/encryption.ts
@@ -6,36 +6,30 @@ const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
 
-export default (key: string) => {
-  return {
-    encrypt: (decryptedData: Buffer) => {
-      const iv = randomBytes(IV_LENGTH);
+type EncryptionFunction = (options: { data: Buffer; key: string }) => Buffer;
 
-      const cipher = createCipheriv(ALGORITHM, key, iv);
+export const encrypt: EncryptionFunction = ({ data, key }) => {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
 
-      return Buffer.concat([
-        keyVersion,
-        iv,
-        cipher.update(decryptedData),
-        cipher.final(),
-        cipher.getAuthTag(),
-      ]);
-    },
-    decrypt: (encryptedData: Buffer) => {
-      // ignoring key version for now since no key rotation is implemented
-      const iv = encryptedData.subarray(
-        keyVersionLength,
-        IV_LENGTH + keyVersionLength
-      );
-      const ciphertext = encryptedData.subarray(
-        IV_LENGTH + keyVersionLength,
-        -AUTH_TAG_LENGTH
-      );
-      const authTag = encryptedData.subarray(-AUTH_TAG_LENGTH);
+  return Buffer.concat([
+    keyVersion,
+    iv,
+    cipher.update(data),
+    cipher.final(),
+    cipher.getAuthTag(),
+  ]);
+};
 
-      const decipher = createDecipheriv(ALGORITHM, key, iv).setAuthTag(authTag);
+export const decrypt: EncryptionFunction = ({ data, key }) => {
+  // ignoring key version for now since no key rotation is implemented
+  const iv = data.subarray(keyVersionLength, IV_LENGTH + keyVersionLength);
+  const ciphertext = data.subarray(
+    IV_LENGTH + keyVersionLength,
+    -AUTH_TAG_LENGTH
+  );
+  const authTag = data.subarray(-AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv).setAuthTag(authTag);
 
-      return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-    },
-  };
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 };

--- a/app/services/encryption.ts
+++ b/app/services/encryption.ts
@@ -1,0 +1,41 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const keyVersion = Buffer.from("v01");
+const keyVersionLength = keyVersion.length;
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+
+export default (key: string) => {
+  return {
+    encrypt: (decryptedData: Buffer) => {
+      const iv = randomBytes(IV_LENGTH);
+
+      const cipher = createCipheriv(ALGORITHM, key, iv);
+
+      return Buffer.concat([
+        keyVersion,
+        iv,
+        cipher.update(decryptedData),
+        cipher.final(),
+        cipher.getAuthTag(),
+      ]);
+    },
+    decrypt: (encryptedData: Buffer) => {
+      // ignoring key version for now since no key rotation is implemented
+      const iv = encryptedData.subarray(
+        keyVersionLength,
+        IV_LENGTH + keyVersionLength
+      );
+      const ciphertext = encryptedData.subarray(
+        IV_LENGTH + keyVersionLength,
+        -AUTH_TAG_LENGTH
+      );
+      const authTag = encryptedData.subarray(-AUTH_TAG_LENGTH);
+
+      const decipher = createDecipheriv(ALGORITHM, key, iv).setAuthTag(authTag);
+
+      return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    },
+  };
+};

--- a/prisma/migrations/20221108205327_add_field_form_data_to_user/migration.sql
+++ b/prisma/migrations/20221108205327_add_field_form_data_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "formData" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   lastDeclarationAt           DateTime?
   fscRequest                  FscRequest?
   pdf                         Pdf?
+  formData                    Json?
 }
 
 model Pdf {


### PR DESCRIPTION
Not active in production environment.
Currently keep storing data in cookies. Should we disable storing in
Redis the form data is still in cookies and nobody is annoyed.
Tests need to be adapted.
Try it out: use the form, delete the form data cookies, refresh page.