### PR TITLE
USEID-843: Collect feedback via survey

### DIFF
--- a/app/components/IdentificationSuccess.tsx
+++ b/app/components/IdentificationSuccess.tsx
@@ -15,6 +15,7 @@ type IdentificationSuccessProps = {
   backButton: BackButton;
   children?: ReactNode;
   identificationType?: string;
+  hasSurveyShown?: boolean;
 };
 
 const renderAdditionalHint = (identificationType?: string) => {
@@ -29,7 +30,7 @@ const renderAdditionalHint = (identificationType?: string) => {
   }
 };
 
-const renderBackButton = (backButton: BackButton) => {
+const renderBackButton = (backButton: BackButton, hasSurveyShown?: boolean) => {
   const classes = "mt-80";
   if (backButton === "summary")
     return (
@@ -38,7 +39,10 @@ const renderBackButton = (backButton: BackButton) => {
       </Button>
     );
   return (
-    <Button to="/formular" className={classes}>
+    <Button
+      to={hasSurveyShown ? "/formular" : "/bundesIdent/survey/success"}
+      className={classes}
+    >
       Weiter zum Formular
     </Button>
   );
@@ -73,7 +77,7 @@ export default function IdentificationSuccess(
           </ul>
         </div>
         {props.children}
-        {renderBackButton(props.backButton)}
+        {renderBackButton(props.backButton, props.hasSurveyShown)}
       </UebersichtStep>
     </ContentContainer>
   );

--- a/app/domain/survey.ts
+++ b/app/domain/survey.ts
@@ -1,0 +1,10 @@
+import { db } from "~/db.server";
+
+export const createSurvey = async (category: string, content: string) => {
+  return db.survey.create({
+    data: {
+      category,
+      content,
+    },
+  });
+};

--- a/app/routes/bundesIdent/_desktop.test.tsx
+++ b/app/routes/bundesIdent/_desktop.test.tsx
@@ -29,8 +29,7 @@ describe("Loader", () => {
         )
       );
 
-      const jsonResponse = await result.json();
-      expect(jsonResponse).toEqual({ hasSurveyShown: false });
+      expect(result).toEqual({ hasSurveyShown: false });
     });
 
     it("returns error if reload", async () => {

--- a/app/routes/bundesIdent/_desktop.test.tsx
+++ b/app/routes/bundesIdent/_desktop.test.tsx
@@ -28,7 +28,9 @@ describe("Loader", () => {
           "existing_user@foo.com"
         )
       );
-      expect(result).toEqual({});
+
+      const jsonResponse = await result.json();
+      expect(jsonResponse).toEqual({ hasSurveyShown: false });
     });
 
     it("returns error if reload", async () => {

--- a/app/routes/bundesIdent/desktop.tsx
+++ b/app/routes/bundesIdent/desktop.tsx
@@ -50,17 +50,10 @@ export const loader: LoaderFunction = async ({ request }) => {
   }
 
   const session = await getSession(request.headers.get("Cookie"));
-  const hasSurveyShown = session.get("hasSurveyShown") || false;
+  const hasSurveyShown = Boolean(session.get("hasSurveyShown"));
   session.set("hasSurveyShown", hasSurveyShown);
 
-  return json(
-    {
-      hasSurveyShown,
-    },
-    {
-      headers: { "Set-Cookie": await commitSession(session) },
-    }
-  );
+  return { hasSurveyShown };
 };
 
 export default function BundesIdentIndex() {

--- a/app/routes/bundesIdent/erfolgreich.tsx
+++ b/app/routes/bundesIdent/erfolgreich.tsx
@@ -23,17 +23,10 @@ export const loader: LoaderFunction = async ({ request }) => {
   }
 
   const session = await getSession(request.headers.get("Cookie"));
-  const hasSurveyShown = session.get("hasSurveyShown") || false;
+  const hasSurveyShown = Boolean(session.get("hasSurveyShown"));
   session.set("hasSurveyShown", hasSurveyShown);
 
-  return json(
-    {
-      hasSurveyShown,
-    },
-    {
-      headers: { "Set-Cookie": await commitSession(session) },
-    }
-  );
+  return { hasSurveyShown };
 };
 
 export default function BundesIdentErfolgreich() {

--- a/app/routes/bundesIdent/survey/dropout.tsx
+++ b/app/routes/bundesIdent/survey/dropout.tsx
@@ -29,8 +29,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   });
 
   const session = await getSession(request.headers.get("Cookie"));
-  const hasSurveyShown = session.get("hasSurveyShown") || true;
-  session.set("hasSurveyShown", hasSurveyShown);
+  session.set("hasSurveyShown", true);
 
   return json(
     {

--- a/app/routes/bundesIdent/survey/dropout.tsx
+++ b/app/routes/bundesIdent/survey/dropout.tsx
@@ -1,0 +1,114 @@
+import {
+  ActionFunction,
+  LoaderFunction,
+  json,
+  redirect,
+} from "@remix-run/node";
+import invariant from "tiny-invariant";
+import { Form, useNavigation } from "@remix-run/react";
+import { isEmpty } from "lodash";
+import {
+  BreadcrumbNavigation,
+  Button,
+  ButtonContainer,
+  ContentContainer,
+  Headline,
+  Textarea,
+} from "~/components";
+import { authenticator } from "~/auth.server";
+import { createSurvey } from "~/domain/survey";
+import { commitSession, getSession } from "~/session.server";
+
+const SURVEY = "survey";
+const SURVEY_CATEGORY = "dropout";
+const IDENT_OPTION_PATH = "/identifikation";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const sessionUser = await authenticator.isAuthenticated(request, {
+    failureRedirect: "/anmelden",
+  });
+
+  const session = await getSession(request.headers.get("Cookie"));
+  const hasSurveyShown = session.get("hasSurveyShown") || true;
+  session.set("hasSurveyShown", hasSurveyShown);
+
+  return json(
+    {
+      email: sessionUser.email,
+    },
+    {
+      headers: { "Set-Cookie": await commitSession(session) },
+    }
+  );
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const userSurvey = formData.get(SURVEY);
+
+  invariant(
+    typeof userSurvey === "string",
+    "expected formData to include survey/feedback text area of type string"
+  );
+
+  if (isEmpty(userSurvey)) {
+    return redirect(IDENT_OPTION_PATH);
+  }
+
+  await createSurvey("dropout", userSurvey);
+  return redirect(IDENT_OPTION_PATH);
+};
+
+export default function SurveySuccess() {
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+
+  return (
+    <>
+      <ContentContainer size="sm-md">
+        <BreadcrumbNavigation />
+        <Headline>
+          Warum haben Sie sich gegen eine Identifikation mit dem Ausweis
+          entschieden?
+        </Headline>
+        <div className="mb-24">
+          <p className="text-18 leading-26">
+            Ihr Feedback hilft uns, das Produkt zu verbessern. Bitte geben Sie
+            keine personenbezogenen Daten wie zum Beispiel Name oder
+            E‑Mail-Adresse ein.
+          </p>
+        </div>
+        <Form method="post">
+          <fieldset disabled={isSubmitting}>
+            <div className="mb-32">
+              <Textarea
+                className="h-[110px]"
+                maxLength={900}
+                name={SURVEY}
+                placeholder="Feedback"
+                data-testid={`${SURVEY}-${SURVEY_CATEGORY}-textarea`}
+              />
+            </div>
+            <ButtonContainer className="md:max-w-[412px]">
+              <Button look="tertiary" to={IDENT_OPTION_PATH}>
+                Überspringen
+              </Button>
+              <Button look="primary">Übernehmen & weiter</Button>
+            </ButtonContainer>
+          </fieldset>
+        </Form>
+      </ContentContainer>
+      <div className="mt-[60px]">
+        <p className="text-18 leading-26">
+          Bei Fragen oder Problemen melden Sie sich unter:{" "}
+          <a
+            href="mailto:hilfe@bundesident.de"
+            className="font-bold text-blue-800 underline"
+          >
+            hilfe@bundesident.de
+          </a>
+        </p>
+      </div>
+    </>
+  );
+}

--- a/app/routes/bundesIdent/survey/success.tsx
+++ b/app/routes/bundesIdent/survey/success.tsx
@@ -29,8 +29,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   });
 
   const session = await getSession(request.headers.get("Cookie"));
-  const hasSurveyShown = session.get("hasSurveyShown") || true;
-  session.set("hasSurveyShown", hasSurveyShown);
+  session.set("hasSurveyShown", true);
 
   return json(
     {

--- a/app/routes/bundesIdent/survey/success.tsx
+++ b/app/routes/bundesIdent/survey/success.tsx
@@ -1,0 +1,98 @@
+import {
+  ActionFunction,
+  LoaderFunction,
+  json,
+  redirect,
+} from "@remix-run/node";
+import invariant from "tiny-invariant";
+import { Form, useNavigation } from "@remix-run/react";
+import { isEmpty } from "lodash";
+import {
+  BreadcrumbNavigation,
+  Button,
+  ButtonContainer,
+  ContentContainer,
+  Headline,
+  Textarea,
+} from "~/components";
+import { authenticator } from "~/auth.server";
+import { createSurvey } from "~/domain/survey";
+import { commitSession, getSession } from "~/session.server";
+
+const SURVEY = "survey";
+const SURVEY_CATEGORY = "success";
+const FORMULAR_PATH = "/formular/welcome";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const sessionUser = await authenticator.isAuthenticated(request, {
+    failureRedirect: "/anmelden",
+  });
+
+  const session = await getSession(request.headers.get("Cookie"));
+  const hasSurveyShown = session.get("hasSurveyShown") || true;
+  session.set("hasSurveyShown", hasSurveyShown);
+
+  return json(
+    {
+      email: sessionUser.email,
+    },
+    {
+      headers: { "Set-Cookie": await commitSession(session) },
+    }
+  );
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const userSurvey = formData.get(SURVEY);
+
+  invariant(
+    typeof userSurvey === "string",
+    "expected formData to include survey/feedback text area of type string"
+  );
+
+  if (isEmpty(userSurvey)) {
+    return redirect(FORMULAR_PATH);
+  }
+
+  await createSurvey("success", userSurvey);
+  return redirect(FORMULAR_PATH);
+};
+
+export default function SurveySuccess() {
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+
+  return (
+    <ContentContainer size="sm-md">
+      <BreadcrumbNavigation />
+      <Headline>Wie fanden Sie die Identifikation mit BundesIdent?</Headline>
+      <div className="mb-24">
+        <p className="text-18 leading-26">
+          Ihr Feedback hilft uns, das Produkt zu verbessern. Bitte geben Sie
+          keine personenbezogenen Daten wie zum Beispiel Name oder
+          E‑Mail-Adresse ein.
+        </p>
+      </div>
+      <Form method="post">
+        <fieldset disabled={isSubmitting}>
+          <div className="mb-32">
+            <Textarea
+              className="h-[110px]"
+              maxLength={900}
+              name={SURVEY}
+              placeholder="Feedback"
+              data-testid={`${SURVEY}-${SURVEY_CATEGORY}-textarea`}
+            />
+          </div>
+          <ButtonContainer className="md:max-w-[412px]">
+            <Button look="tertiary" to={FORMULAR_PATH}>
+              Überspringen
+            </Button>
+            <Button look="primary">Übernehmen & weiter</Button>
+          </ButtonContainer>
+        </fieldset>
+      </Form>
+    </ContentContainer>
+  );
+}

--- a/app/routes/identifikation/erfolgreich.tsx
+++ b/app/routes/identifikation/erfolgreich.tsx
@@ -15,17 +15,10 @@ export const loader: LoaderFunction = async ({ request }) => {
   });
 
   const session = await getSession(request.headers.get("Cookie"));
-  const hasSurveyShown = session.get("hasSurveyShown") || false;
+  const hasSurveyShown = Boolean(session.get("hasSurveyShown"));
   session.set("hasSurveyShown", hasSurveyShown);
 
-  return json(
-    {
-      hasSurveyShown,
-    },
-    {
-      headers: { "Set-Cookie": await commitSession(session) },
-    }
-  );
+  return { hasSurveyShown };
 };
 
 export default function IdentifikationErfolgreich() {

--- a/prisma/migrations/20230303080951_create_table_survey/migration.sql
+++ b/prisma/migrations/20230303080951_create_table_survey/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "Survey" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "category" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+
+    CONSTRAINT "Survey_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-musl"]
+  provider        = "prisma-client-js"
+  binaryTargets   = ["native", "linux-musl"]
   previewFeatures = ["interactiveTransactions"]
 }
 
@@ -55,4 +55,11 @@ model AuditLogV2 {
   version   String
   user      String
   data      String
+}
+
+model Survey {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  category  String
+  content   String
 }

--- a/test/e2e/survey.spec.ts
+++ b/test/e2e/survey.spec.ts
@@ -1,0 +1,101 @@
+/// <reference types="../../cypress/support" />
+
+describe("Survey feedback", () => {
+  describe("when user is successfully identified", () => {
+    beforeEach(() => {
+      cy.task("setUserIdentified", {
+        email: "foo@bar.com",
+      });
+      cy.login();
+    });
+
+    it("should show survey page once on the BundesIdent success identification page", () => {
+      cy.visit("/bundesIdent/erfolgreich");
+      cy.contains("div", "Weiter zum Formular").click();
+      cy.url().should("include", "/bundesIdent/survey/success");
+
+      cy.visit("/bundesIdent/erfolgreich");
+      cy.contains("div", "Weiter zum Formular").click();
+      cy.url().should("include", "/formular/welcome");
+    });
+
+    it("should redirect user to formular page after submitting the survey", () => {
+      cy.visit("/bundesIdent/erfolgreich");
+      cy.contains("div", "Weiter zum Formular").click();
+      cy.url().should("include", "/bundesIdent/survey/success");
+      cy.get('[data-testid="survey-success-textarea"]').type("nice feedback");
+      cy.contains("button", "Übernehmen & weiter").click();
+      cy.url().should("include", "/formular/welcome");
+    });
+
+    it("should show survey page once on the generic success identification page", () => {
+      cy.visit("/identifikation/erfolgreich");
+      cy.contains("div", "Weiter zum Formular").click();
+      cy.url().should("include", "/bundesIdent/survey/success");
+
+      cy.visit("/identifikation/erfolgreich");
+      cy.contains("div", "Weiter zum Formular").click();
+      cy.url().should("include", "/formular/welcome");
+    });
+  });
+
+  describe("when user is not identified", () => {
+    beforeEach(() => {
+      cy.task("setUserUnidentified", {
+        email: "foo@bar.com",
+      });
+      cy.login();
+    });
+
+    it("should show survey page once when users goes back to the identification options page", () => {
+      // when first visit
+      cy.visit("/identifikation");
+      cy.contains("h1", "Mit welcher Option möchten Sie sich identifizieren?");
+      cy.contains("div", "Identifikation mit Ausweis").click();
+
+      cy.url().should("include", "/bundesIdent/desktop");
+      cy.contains(
+        "h1",
+        "Schnell und sicher mit der BundesIdent App auf Ihrem Smartphone identifizieren"
+      );
+      cy.contains("div", "Zurück zu Identifikationsoptionen").click();
+
+      // then show survey
+      cy.url().should("include", "/bundesIdent/survey/dropout");
+      cy.contains(
+        "h1",
+        "Warum haben Sie sich gegen eine Identifikation mit dem Ausweis entschieden?"
+      );
+      cy.contains("a", "Überspringen").click();
+
+      cy.url().should("include", "/identifikation");
+      cy.contains("h1", "Mit welcher Option möchten Sie sich identifizieren?");
+
+      // when second visit
+      cy.contains("div", "Identifikation mit Ausweis").click();
+
+      cy.url().should("include", "/bundesIdent/desktop");
+      cy.contains(
+        "h1",
+        "Schnell und sicher mit der BundesIdent App auf Ihrem Smartphone identifizieren"
+      );
+      cy.contains("div", "Zurück zu Identifikationsoptionen").click();
+
+      // then no survey
+      cy.url().should("include", "/identifikation");
+      cy.contains("h1", "Mit welcher Option möchten Sie sich identifizieren?");
+    });
+
+    it("should redirect user to identification option page after submitting the survey", () => {
+      cy.visit("/identifikation");
+      cy.contains("div", "Identifikation mit Ausweis").click();
+      cy.contains("div", "Zurück zu Identifikationsoptionen").click();
+      cy.url().should("include", "/bundesIdent/survey/dropout");
+      cy.get('[data-testid="survey-dropout-textarea"]').type(
+        "dropout feedback"
+      );
+      cy.contains("button", "Übernehmen & weiter").click();
+      cy.url().should("include", "/identifikation");
+    });
+  });
+});

--- a/test/integration/survey.test.ts
+++ b/test/integration/survey.test.ts
@@ -1,8 +1,10 @@
 import { createSurvey } from "~/domain/survey";
 
 describe("Survey", () => {
-  it("should not return when survey is submitted", async () => {
+  it("should return when survey is submitted", async () => {
     const newSurvey = await createSurvey("dropout", "nice survey");
-    expect(newSurvey).toBeUndefined();
+    expect(newSurvey).not.toBeUndefined();
+    expect(newSurvey.category).toEqual("dropout");
+    expect(newSurvey.content).toEqual("nice survey");
   });
 });

--- a/test/integration/survey.test.ts
+++ b/test/integration/survey.test.ts
@@ -1,0 +1,8 @@
+import { createSurvey } from "~/domain/survey";
+
+describe("Survey", () => {
+  it("should not return when survey is submitted", async () => {
+    const newSurvey = await createSurvey("dropout", "nice survey");
+    expect(newSurvey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
_PR Context: first-time feature dev for GST_

### Goal
As BundesIdent-team we want to understand, why users are not using BundesIdent to identify for GST. We can derive measures to win more users if we know why that is.

### Proposed changes
- Create a new table with no reference to the user
- Show the survey only once
- When a user submits, we don't show any feedback/notification on the error or on feedback submitted (