### PR TITLE
Add cron job to delete outdated survey entries

### DIFF
--- a/app/cron.server.ts
+++ b/app/cron.server.ts
@@ -124,9 +124,35 @@ const scheduleUpdateEricaRequest = (cronExpression: string) => {
   });
 };
 
+export const deleteOutdatedSurveyResults = async () => {
+  try {
+    const now = new Date();
+    const oneDayAgo = new Date(now.setUTCDate(now.getUTCDate() - 1));
+    const queryResult = await db.survey.deleteMany({
+      where: {
+        createdAt: {
+          lte: oneDayAgo,
+        },
+      },
+    });
+    console.log("Deleted %d outdated survey results.", queryResult.count);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const scheduleSurveyCleanUp = (cronExpression: string) => {
+  console.info(
+    "Schedule deleting outdated survey entries with cron expression: %s",
+    cronExpression
+  );
+  schedule(cronExpression, async () => deleteOutdatedSurveyResults());
+};
+
 export const jobs = {
   schedulePdfCleanup,
   scheduleTransferticketCleanup,
   scheduleAccountCleanup,
   scheduleUpdateEricaRequest,
+  scheduleSurveyCleanUp,
 };

--- a/app/util/csrf.test.ts
+++ b/app/util/csrf.test.ts
@@ -1,11 +1,10 @@
-import { Session } from "@remix-run/node";
+import { Session, createSession } from "@remix-run/node";
 import {
   appendCsrfToken,
   createCsrfToken,
   formTokenIsValid,
   SESSION_KEY,
 } from "./csrf";
-import { createSession } from "@remix-run/node";
 
 describe("appendCsrfToken", () => {
   describe("with empty session", () => {


### PR DESCRIPTION
This should allow us to delete old survey entries each day. They can be deleted after one day because we check them every hour.

# Changes
- Add a new cronjob that deletes all surveys older than one day

# Feedback
- This cronjob would not run only once a day. However, I think this would still be fine. wdyt?
