### PR TITLE
USEID-1015 Always show primary option page

### DIFF
--- a/app/domain/identificationStatus.ts
+++ b/app/domain/identificationStatus.ts
@@ -36,9 +36,21 @@ export const needsToStartIdentification = (user: User) => {
   return !user.identified && !user.fscRequest;
 };
 
-export const isEligibleForPrimaryOption = (
-  isServiceOnline: boolean,
+export const hasPrimaryOptionEligibility = (
+  requestUrl: string,
+  serviceAvailability: boolean,
   user: User
 ) => {
-  return isServiceOnline && needsToStartIdentification(user);
+  const originQueryParam = new URL(requestUrl).searchParams.get("origin");
+  const isPrimaryOptionRequest = originQueryParam === "primaryoption";
+  const isDropoutSurveyRequest = originQueryParam === "survey";
+  const isBackButtonRequest = originQueryParam === "back";
+
+  return (
+    !isPrimaryOptionRequest &&
+    !isDropoutSurveyRequest &&
+    !isBackButtonRequest &&
+    serviceAvailability &&
+    needsToStartIdentification(user)
+  );
 };

--- a/app/domain/identificationStatus.ts
+++ b/app/domain/identificationStatus.ts
@@ -36,14 +36,9 @@ export const needsToStartIdentification = (user: User) => {
   return !user.identified && !user.fscRequest;
 };
 
-export const showBundesidentPrimayOptionPage = (
-  bundesIdentIsOnline: boolean,
-  hasPrimaryOptionShown: boolean,
+export const isEligibleForPrimaryOption = (
+  isServiceOnline: boolean,
   user: User
 ) => {
-  return (
-    bundesIdentIsOnline &&
-    !hasPrimaryOptionShown &&
-    needsToStartIdentification(user)
-  );
+  return isServiceOnline && needsToStartIdentification(user);
 };

--- a/app/routes/bundesIdent/primaryoption.tsx
+++ b/app/routes/bundesIdent/primaryoption.tsx
@@ -1,4 +1,4 @@
-import { LoaderFunction, MetaFunction, json, redirect } from "@remix-run/node";
+import { LoaderFunction, MetaFunction, redirect } from "@remix-run/node";
 import { pageTitle } from "~/util/pageTitle";
 import { authenticator } from "~/auth.server";
 import {
@@ -10,7 +10,6 @@ import {
 } from "~/components";
 import Bolt from "~/components/icons/mui/Bolt";
 import bundesIdentCardsImage from "~/assets/images/bundesident-cards.png";
-import { commitSession, getSession } from "~/session.server";
 import { findUserByEmail } from "~/domain/user";
 import { logoutDeletedUser } from "~/util/logoutDeletedUser";
 
@@ -34,18 +33,10 @@ export const loader: LoaderFunction = async ({ request }) => {
     return redirect("/identifikation/erfolgreich");
   }
 
-  const session = await getSession(request.headers.get("Cookie"));
-  session.set("hasPrimaryOptionShown", true);
-
-  return json(
-    {},
-    {
-      headers: { "Set-Cookie": await commitSession(session) },
-    }
-  );
+  return {};
 };
 
-export default function BundesIdentVoraussetzung() {
+export default function PrimaryOption() {
   return (
     <>
       <ContentContainer size="sm-md">
@@ -97,7 +88,7 @@ export default function BundesIdentVoraussetzung() {
         <Button
           className="w-full lg:max-w-[267px]"
           look="tertiary"
-          to="/identifikation"
+          to="/identifikation?origin=primaryoption"
         >
           Alle Identifikationsoptionen
         </Button>

--- a/app/routes/bundesIdent/survey/dropout.tsx
+++ b/app/routes/bundesIdent/survey/dropout.tsx
@@ -21,7 +21,7 @@ import { commitSession, getSession } from "~/session.server";
 
 const SURVEY = "survey";
 const SURVEY_CATEGORY = "dropout";
-const IDENT_OPTION_PATH = "/identifikation";
+const IDENT_OPTION_PATH = "/identifikation?origin=survey";
 
 export const loader: LoaderFunction = async ({ request }) => {
   const sessionUser = await authenticator.isAuthenticated(request, {

--- a/app/routes/bundesIdent/voraussetzung.tsx
+++ b/app/routes/bundesIdent/voraussetzung.tsx
@@ -71,7 +71,9 @@ export default function BundesIdentVoraussetzung() {
             className="w-full lg:max-w-[138px]"
             look="secondary"
             to={
-              hasSurveyShown ? "/identifikation" : "/bundesIdent/survey/dropout"
+              hasSurveyShown
+                ? "/identifikation?origin=back"
+                : "/bundesIdent/survey/dropout"
             }
           >
             Zurück

--- a/app/routes/identifikation/index.tsx
+++ b/app/routes/identifikation/index.tsx
@@ -61,10 +61,12 @@ export const loader: LoaderFunction = async ({ request }) => {
   const originQueryParam = new URL(request.url).searchParams.get("origin");
   const isPrimaryOptionRequest = originQueryParam === "primaryoption";
   const isDropoutSurveyRequest = originQueryParam === "survey";
+  const isBackButtonRequest = originQueryParam === "back";
 
   if (
     !isPrimaryOptionRequest &&
     !isDropoutSurveyRequest &&
+    !isBackButtonRequest &&
     shouldShowPrimaryOption
   ) {
     return redirect("/bundesIdent/primaryoption");

--- a/app/routes/identifikation/index.tsx
+++ b/app/routes/identifikation/index.tsx
@@ -11,7 +11,12 @@ import ident3 from "~/assets/images/ident-3.png";
 import bundesIdentCardsImage from "~/assets/images/bundesident-cards.png";
 import { ReactNode } from "react";
 import classNames from "classnames";
-import { LoaderFunction, MetaFunction, redirect } from "@remix-run/node";
+import {
+  LoaderFunction,
+  MetaFunction,
+  Request,
+  redirect,
+} from "@remix-run/node";
 import { authenticator } from "~/auth.server";
 import { findUserByEmail } from "~/domain/user";
 import SectionLabel from "../../components/navigation/SectionLabel";
@@ -27,7 +32,7 @@ import { isMobileUserAgent } from "~/util/isMobileUserAgent";
 import TeaserIdentCard from "~/components/TeaserIdentCard";
 import {
   canEnterFsc,
-  isEligibleForPrimaryOption,
+  hasPrimaryOptionEligibility,
 } from "~/domain/identificationStatus";
 import { logoutDeletedUser } from "~/util/logoutDeletedUser";
 import LinkWithArrow from "~/components/LinkWithArrow";
@@ -53,22 +58,13 @@ export const loader: LoaderFunction = async ({ request }) => {
   const bundesIdentIsOnline =
     !flags.isBundesIdentDisabled() && !flags.isBundesIdentDown();
 
-  const shouldShowPrimaryOption = isEligibleForPrimaryOption(
+  const shouldShowPrimaryOption = hasPrimaryOptionEligibility(
+    request.url,
     bundesIdentIsOnline,
     dbUser
   );
 
-  const originQueryParam = new URL(request.url).searchParams.get("origin");
-  const isPrimaryOptionRequest = originQueryParam === "primaryoption";
-  const isDropoutSurveyRequest = originQueryParam === "survey";
-  const isBackButtonRequest = originQueryParam === "back";
-
-  if (
-    !isPrimaryOptionRequest &&
-    !isDropoutSurveyRequest &&
-    !isBackButtonRequest &&
-    shouldShowPrimaryOption
-  ) {
+  if (shouldShowPrimaryOption) {
     return redirect("/bundesIdent/primaryoption");
   }
 

--- a/app/routes/identifikation/index.tsx
+++ b/app/routes/identifikation/index.tsx
@@ -27,11 +27,10 @@ import { isMobileUserAgent } from "~/util/isMobileUserAgent";
 import TeaserIdentCard from "~/components/TeaserIdentCard";
 import {
   canEnterFsc,
-  showBundesidentPrimayOptionPage,
+  isEligibleForPrimaryOption,
 } from "~/domain/identificationStatus";
 import { logoutDeletedUser } from "~/util/logoutDeletedUser";
 import LinkWithArrow from "~/components/LinkWithArrow";
-import { getSession } from "~/session.server";
 
 export const meta: MetaFunction = () => {
   return {
@@ -53,15 +52,21 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   const bundesIdentIsOnline =
     !flags.isBundesIdentDisabled() && !flags.isBundesIdentDown();
-  const session = await getSession(request.headers.get("Cookie"));
-  const hasPrimaryOptionShown = Boolean(session.get("hasPrimaryOptionShown"));
-  const shouldShowBundesidentPrimayOptionPage = showBundesidentPrimayOptionPage(
+
+  const shouldShowPrimaryOption = isEligibleForPrimaryOption(
     bundesIdentIsOnline,
-    hasPrimaryOptionShown,
     dbUser
   );
 
-  if (shouldShowBundesidentPrimayOptionPage) {
+  const originQueryParam = new URL(request.url).searchParams.get("origin");
+  const isPrimaryOptionRequest = originQueryParam === "primaryoption";
+  const isDropoutSurveyRequest = originQueryParam === "survey";
+
+  if (
+    !isPrimaryOptionRequest &&
+    !isDropoutSurveyRequest &&
+    shouldShowPrimaryOption
+  ) {
     return redirect("/bundesIdent/primaryoption");
   }
 

--- a/app/routes/identifikation/index.tsx
+++ b/app/routes/identifikation/index.tsx
@@ -11,12 +11,7 @@ import ident3 from "~/assets/images/ident-3.png";
 import bundesIdentCardsImage from "~/assets/images/bundesident-cards.png";
 import { ReactNode } from "react";
 import classNames from "classnames";
-import {
-  LoaderFunction,
-  MetaFunction,
-  Request,
-  redirect,
-} from "@remix-run/node";
+import { LoaderFunction, MetaFunction, redirect } from "@remix-run/node";
 import { authenticator } from "~/auth.server";
 import { findUserByEmail } from "~/domain/user";
 import SectionLabel from "../../components/navigation/SectionLabel";

--- a/test/e2e/primaryoption.spec.ts
+++ b/test/e2e/primaryoption.spec.ts
@@ -1,47 +1,11 @@
 /// <reference types="../../cypress/support" />
 
 describe("Primary option page", () => {
-  it("should show primary option page once", () => {
-    cy.login();
-    // WHEN I successfully login
-    cy.visit("/anmelden/erfolgreich");
-    // THEN I click continue button
-    cy.contains("a", "Verstanden & weiter").click();
-    // THEN I should see bundesident primary option page
-    cy.contains(
-      "h1",
-      "Möchten Sie sich in wenigen Minuten mit Ihrem Ausweis identifizieren?"
-    );
-    // THEN I click Identifikation mit Ausweis
-    cy.contains("a", "Identifikation mit Ausweis").click();
-    // WHEN I visit the success login page again
-    cy.visit("/anmelden/erfolgreich");
-    // THEN I click continue button
-    cy.contains("a", "Verstanden & weiter").click();
-    // THEN I should not see bundesident primary page
-    cy.contains("h1", "Mit welcher Option möchten Sie sich identifizieren?");
-    cy.url().should("include", "/identifikation");
-  });
-
   describe("user clicks on sidebar identifikation button", () => {
     beforeEach(() => {
       // WHEN I successfully login
       cy.login();
       cy.viewport(1200, 1000); // element is invisible, we need to set the screen bigger
-    });
-    it("should see bundesident once", () => {
-      cy.visit("/anmelden/erfolgreich");
-      // THEN I click identification button on the left sidebar
-      cy.get("#sidebar-navigation-content #icon-lock").click();
-      // THEN I should see bundesident primary page
-      cy.contains(
-        "h1",
-        "Möchten Sie sich in wenigen Minuten mit Ihrem Ausweis identifizieren?"
-      );
-      // THEN I click identification button on the left sidebar
-      cy.get("#sidebar-navigation-content #icon-lock").click();
-      // THEN I should see identification option page
-      cy.contains("h1", "Mit welcher Option möchten Sie sich identifizieren?");
     });
 
     it("should go to primary option page when in /formular route", () => {

--- a/test/e2e/primaryoption.spec.ts
+++ b/test/e2e/primaryoption.spec.ts
@@ -1,6 +1,19 @@
 /// <reference types="../../cypress/support" />
 
 describe("Primary option page", () => {
+  it("should show primary option page once", () => {
+    cy.login();
+    // WHEN I successfully login
+    cy.visit("/anmelden/erfolgreich");
+    // THEN I click continue button
+    cy.contains("a", "Verstanden & weiter").click();
+    // THEN I should see bundesident primary option page
+    cy.contains(
+      "h1",
+      "Möchten Sie sich in wenigen Minuten mit Ihrem Ausweis identifizieren?"
+    );
+  });
+
   describe("user clicks on sidebar identifikation button", () => {
     beforeEach(() => {
       // WHEN I successfully login

--- a/test/e2e/survey.spec.ts
+++ b/test/e2e/survey.spec.ts
@@ -101,15 +101,25 @@ describe("Survey feedback", () => {
       });
 
       it("should redirect user to identification option page after submitting the survey", () => {
+        // WHEN I visit identifikation page
         cy.visit("/identifikation");
+        // THEN I get redirected to primary option page
+        cy.contains(
+          "h1",
+          "Möchten Sie sich in wenigen Minuten mit Ihrem Ausweis identifizieren?"
+        );
+        // THEN I choose identification with ID
         cy.contains("div", "Identifikation mit Ausweis").click();
+        // THEN I click back
         cy.contains("div", "Zurück").click();
+        // THEN I should see dropout survey
         cy.url().should("include", "/bundesIdent/survey/dropout");
+        // WHEN I fill and submit the survey
         cy.get('[data-testid="survey-dropout-textarea"]').type(
           "dropout feedback"
         );
         cy.contains("button", "Übernehmen & weiter").click();
-        cy.url().should("include", "/identifikation");
+        cy.url().should("include", "/identifikation?origin=survey");
       });
     });
 


### PR DESCRIPTION
Current state:
- Primary option is shown once to the user

Proposed changes:
- Always show the primary option via removal of `hasPrimaryOptionShown` session
- `origin` query param introduction