### PR TITLE
Bump remix to 1.17.1

### DIFF
--- a/app/routes/__infoLayout/pruefen/_step.tsx
+++ b/app/routes/__infoLayout/pruefen/_step.tsx
@@ -290,7 +290,7 @@ export type StepComponentFunction = (
 ) => JSX.Element;
 
 export function Step() {
-  const loaderData: LoaderData = useLoaderData();
+  const loaderData = useLoaderData<typeof loader>();
   const actionData: ActionData = useActionData() as ActionData;
   const navigation = useNavigation();
   const isSubmitting = Boolean(navigation.state === "submitting");

--- a/app/routes/formular/_step.tsx
+++ b/app/routes/formular/_step.tsx
@@ -266,7 +266,7 @@ export type HeadlineComponentFunction = (props: {
 }) => JSX.Element;
 
 export function Step() {
-  const loaderData: LoaderData = useLoaderData();
+  const loaderData = useLoaderData<typeof loader>();
   const actionData: ActionData = useActionData() as ActionData;
   const navigation = useNavigation();
   const isSubmitting = Boolean(navigation.state === "submitting");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "dependencies": {
         "@node-saml/node-saml": "^4.0.4",
         "@prisma/client": "^4.15.0",
-        "@remix-run/express": "^1.16.0",
-        "@remix-run/node": "^1.16.0",
-        "@remix-run/react": "^1.16.0",
+        "@remix-run/express": "^1.17.1",
+        "@remix-run/node": "^1.17.1",
+        "@remix-run/react": "^1.17.1",
         "@sentry/remix": "^7.55.2",
         "@tailwindcss/typography": "^0.5.9",
         "@xstate/graph": "^1.4.2",
@@ -3768,31 +3768,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@remix-run/dev/node_modules/@remix-run/router": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
-      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@remix-run/dev/node_modules/@remix-run/server-runtime": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.17.1.tgz",
-      "integrity": "sha512-PuLDaf7WmrOaQzM70yCcM6Jm+g+UHzeBFvocxdqohJnO/8+/n5pFIKHwhooqcSq2TR0WtVpSVhCakdywiOH2mA==",
-      "dev": true,
-      "dependencies": {
-        "@remix-run/router": "1.6.3",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.4.1",
-        "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@remix-run/dev/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4092,11 +4067,11 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.16.0.tgz",
-      "integrity": "sha512-V6krwEHajFtpmp/Ds88Ml3HnVoZXrtBTgNaqIxnbiTKeIURKaVQbA0+BTIf3jwnFrL8jFTOFA0Dns3honKAHfw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.17.1.tgz",
+      "integrity": "sha512-VOrrdl4dh9ZLgRzdt8bf7E+iFMnxsjFl1VtfLP1KgR8Pw4q872L5pwnOEtYA2PVoXbVopvKVcy9MnL1gQsTDWg==",
       "dependencies": {
-        "@remix-run/node": "1.16.0"
+        "@remix-run/node": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -4106,11 +4081,11 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.16.0.tgz",
-      "integrity": "sha512-2JtU3sVWDkyLcZ2prLovSbp4/K/mjbei1r9Qv6D9+fKgJFu3YjCPKfPiSj+T4My5rCG7azuKs5KOtmnwKBavrA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.17.1.tgz",
+      "integrity": "sha512-TDTWOrD1uAizlNRJaw0NjdsxtiYAiwjiBdXZ0sPdA7ABSqK1BH5I4NxxGpdcDPIbEReNRUTPnlu/bYqjG4JDag==",
       "dependencies": {
-        "@remix-run/server-runtime": "1.16.0",
+        "@remix-run/server-runtime": "1.17.1",
         "@remix-run/web-fetch": "^4.3.4",
         "@remix-run/web-file": "^3.0.2",
         "@remix-run/web-stream": "^1.0.3",
@@ -4125,12 +4100,12 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.16.0.tgz",
-      "integrity": "sha512-pFhlEuqnlk8xqpIkKJ/FLSG16NZ25g9/bQcol/zVW1zllgpL4NTXfy+xTGaCmuB3GsG5nVLLvUFlDsN+KBWfSw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.17.1.tgz",
+      "integrity": "sha512-KDrkVkIFeDfn1xW3L8lqe0VlG7KsngdUKz09FSc9e3zYvJJV4ix998Y0qpfkDp/OnLFy2FtHzkh7c3OMnpOBnA==",
       "dependencies": {
-        "@remix-run/router": "1.6.0",
-        "react-router-dom": "6.11.0"
+        "@remix-run/router": "1.6.3",
+        "react-router-dom": "6.13.0"
       },
       "engines": {
         "node": ">=14"
@@ -4141,19 +4116,19 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.0.tgz",
-      "integrity": "sha512-N13NRw3T2+6Xi9J//3CGLsK2OqC8NMme3d/YX+nh05K9YHWGcv8DycHJrqGScSP4T75o8IN6nqIMhVFU8ohg8w==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
+      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.16.0.tgz",
-      "integrity": "sha512-a8rfS2SJ2nWhyGikXo+uknOSl1gW1/maDYuiG4Ki2wbVmF0v5mhJhlyB+1l+BjvXw+ZTS9HIiSQkg6L6JWqEcQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.17.1.tgz",
+      "integrity": "sha512-PuLDaf7WmrOaQzM70yCcM6Jm+g+UHzeBFvocxdqohJnO/8+/n5pFIKHwhooqcSq2TR0WtVpSVhCakdywiOH2mA==",
       "dependencies": {
-        "@remix-run/router": "1.6.0",
+        "@remix-run/router": "1.6.3",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.4.1",
         "set-cookie-parser": "^2.4.8",
@@ -19346,11 +19321,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.0.tgz",
-      "integrity": "sha512-hTm6KKNpj9SDG4syIWRjCU219O0RZY8RUPobCFt9p+PlF7nnkRgMoh2DieTKvw3F3Mw6zg565HGnSv8BuoY5oQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.13.0.tgz",
+      "integrity": "sha512-Si6KnfEnJw7gUQkNa70dlpI1bul46FuSxX5t5WwlUBxE25DAz2BjVkwaK8Y2s242bQrZPXCpmwLPtIO5pv4tXg==",
       "dependencies": {
-        "@remix-run/router": "1.6.0"
+        "@remix-run/router": "1.6.3"
       },
       "engines": {
         "node": ">=14"
@@ -19360,12 +19335,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.0.tgz",
-      "integrity": "sha512-Q3mK1c/CYoF++J6ZINz7EZzwlgSOZK/kc7lxIA7PhtWhKju4KfF1WHqlx0kVCIFJAWztuYVpXZeljEbds8z4Og==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.13.0.tgz",
+      "integrity": "sha512-6Nqoqd7fgwxxVGdbiMHTpDHCYPq62d7Wk1Of7B82vH7ZPwwsRaIa22zRZKPPg413R5REVNiyuQPKDG1bubcOFA==",
       "dependencies": {
-        "@remix-run/router": "1.6.0",
-        "react-router": "6.11.0"
+        "@remix-run/router": "1.6.3",
+        "react-router": "6.13.0"
       },
       "engines": {
         "node": ">=14"
@@ -25615,25 +25590,6 @@
           "dev": true,
           "optional": true
         },
-        "@remix-run/router": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
-          "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
-          "dev": true
-        },
-        "@remix-run/server-runtime": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.17.1.tgz",
-          "integrity": "sha512-PuLDaf7WmrOaQzM70yCcM6Jm+g+UHzeBFvocxdqohJnO/8+/n5pFIKHwhooqcSq2TR0WtVpSVhCakdywiOH2mA==",
-          "dev": true,
-          "requires": {
-            "@remix-run/router": "1.6.3",
-            "@web3-storage/multipart-parser": "^1.0.0",
-            "cookie": "^0.4.1",
-            "set-cookie-parser": "^2.4.8",
-            "source-map": "^0.7.3"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -25831,19 +25787,19 @@
       }
     },
     "@remix-run/express": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.16.0.tgz",
-      "integrity": "sha512-V6krwEHajFtpmp/Ds88Ml3HnVoZXrtBTgNaqIxnbiTKeIURKaVQbA0+BTIf3jwnFrL8jFTOFA0Dns3honKAHfw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-1.17.1.tgz",
+      "integrity": "sha512-VOrrdl4dh9ZLgRzdt8bf7E+iFMnxsjFl1VtfLP1KgR8Pw4q872L5pwnOEtYA2PVoXbVopvKVcy9MnL1gQsTDWg==",
       "requires": {
-        "@remix-run/node": "1.16.0"
+        "@remix-run/node": "1.17.1"
       }
     },
     "@remix-run/node": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.16.0.tgz",
-      "integrity": "sha512-2JtU3sVWDkyLcZ2prLovSbp4/K/mjbei1r9Qv6D9+fKgJFu3YjCPKfPiSj+T4My5rCG7azuKs5KOtmnwKBavrA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-1.17.1.tgz",
+      "integrity": "sha512-TDTWOrD1uAizlNRJaw0NjdsxtiYAiwjiBdXZ0sPdA7ABSqK1BH5I4NxxGpdcDPIbEReNRUTPnlu/bYqjG4JDag==",
       "requires": {
-        "@remix-run/server-runtime": "1.16.0",
+        "@remix-run/server-runtime": "1.17.1",
         "@remix-run/web-fetch": "^4.3.4",
         "@remix-run/web-file": "^3.0.2",
         "@remix-run/web-stream": "^1.0.3",
@@ -25855,25 +25811,25 @@
       }
     },
     "@remix-run/react": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.16.0.tgz",
-      "integrity": "sha512-pFhlEuqnlk8xqpIkKJ/FLSG16NZ25g9/bQcol/zVW1zllgpL4NTXfy+xTGaCmuB3GsG5nVLLvUFlDsN+KBWfSw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.17.1.tgz",
+      "integrity": "sha512-KDrkVkIFeDfn1xW3L8lqe0VlG7KsngdUKz09FSc9e3zYvJJV4ix998Y0qpfkDp/OnLFy2FtHzkh7c3OMnpOBnA==",
       "requires": {
-        "@remix-run/router": "1.6.0",
-        "react-router-dom": "6.11.0"
+        "@remix-run/router": "1.6.3",
+        "react-router-dom": "6.13.0"
       }
     },
     "@remix-run/router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.0.tgz",
-      "integrity": "sha512-N13NRw3T2+6Xi9J//3CGLsK2OqC8NMme3d/YX+nh05K9YHWGcv8DycHJrqGScSP4T75o8IN6nqIMhVFU8ohg8w=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
+      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q=="
     },
     "@remix-run/server-runtime": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.16.0.tgz",
-      "integrity": "sha512-a8rfS2SJ2nWhyGikXo+uknOSl1gW1/maDYuiG4Ki2wbVmF0v5mhJhlyB+1l+BjvXw+ZTS9HIiSQkg6L6JWqEcQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.17.1.tgz",
+      "integrity": "sha512-PuLDaf7WmrOaQzM70yCcM6Jm+g+UHzeBFvocxdqohJnO/8+/n5pFIKHwhooqcSq2TR0WtVpSVhCakdywiOH2mA==",
       "requires": {
-        "@remix-run/router": "1.6.0",
+        "@remix-run/router": "1.6.3",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.4.1",
         "set-cookie-parser": "^2.4.8",
@@ -36971,20 +36927,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.0.tgz",
-      "integrity": "sha512-hTm6KKNpj9SDG4syIWRjCU219O0RZY8RUPobCFt9p+PlF7nnkRgMoh2DieTKvw3F3Mw6zg565HGnSv8BuoY5oQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.13.0.tgz",
+      "integrity": "sha512-Si6KnfEnJw7gUQkNa70dlpI1bul46FuSxX5t5WwlUBxE25DAz2BjVkwaK8Y2s242bQrZPXCpmwLPtIO5pv4tXg==",
       "requires": {
-        "@remix-run/router": "1.6.0"
+        "@remix-run/router": "1.6.3"
       }
     },
     "react-router-dom": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.0.tgz",
-      "integrity": "sha512-Q3mK1c/CYoF++J6ZINz7EZzwlgSOZK/kc7lxIA7PhtWhKju4KfF1WHqlx0kVCIFJAWztuYVpXZeljEbds8z4Og==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.13.0.tgz",
+      "integrity": "sha512-6Nqoqd7fgwxxVGdbiMHTpDHCYPq62d7Wk1Of7B82vH7ZPwwsRaIa22zRZKPPg413R5REVNiyuQPKDG1bubcOFA==",
       "requires": {
-        "@remix-run/router": "1.6.0",
-        "react-router": "6.11.0"
+        "@remix-run/router": "1.6.3",
+        "react-router": "6.13.0"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
   "dependencies": {
     "@node-saml/node-saml": "^4.0.4",
     "@prisma/client": "^4.15.0",
-    "@remix-run/express": "^1.16.0",
-    "@remix-run/node": "^1.16.0",
-    "@remix-run/react": "^1.16.0",
+    "@remix-run/express": "^1.17.1",
+    "@remix-run/node": "^1.17.1",
+    "@remix-run/react": "^1.17.1",
     "@sentry/remix": "^7.55.2",
     "@tailwindcss/typography": "^0.5.9",
     "@xstate/graph": "^1.4.2",


### PR DESCRIPTION
The code throws type error

```
app/routes/__infoLayout/pruefen/_step.tsx:293:9 - error TS2740: Type '{ [x: string]: any; }' is missing the following properties from type 'LoaderData': formData, allData, i18n, startPath, and 10 more.

293   const loaderData: LoaderData = useLoaderData();
            ~~~~~~~~~~

app/routes/formular/_step.tsx:269:9 - error TS2740: Type '{ [x: string]: any; }' is missing the following properties from type 'LoaderData': formData, allData, i18n, backUrl, and 2 more.

269   const loaderData: LoaderData = useLoaderData();
            ~~~~~~~~~~

```
I checked the documentation https://remix.run/docs/en/main/hooks/use-loader-data and use the following instead

```diff
-const loaderData: LoaderData = useLoaderData();
+const loaderData = useLoaderData<typeof loader>();
```